### PR TITLE
chore(test): add Honeycomb exporter for trace validation

### DIFF
--- a/packages/node/test/integration/effect/fiberset/context-leak.integration.test.ts
+++ b/packages/node/test/integration/effect/fiberset/context-leak.integration.test.ts
@@ -121,26 +121,19 @@ describe('FiberSet.run Context Leakage', () => {
   // Helper to suppress harmless connection errors during test cleanup
   const suppressShutdownErrors = () => {
     const isHarmlessConnectionError = (error: any): boolean => {
-      // Check for direct error properties
-      if (
-        error &&
-        typeof error === 'object' &&
-        error.code === 'ECONNREFUSED' &&
-        (error.address === '127.0.0.1' || error.address === '::1') &&
-        error.port === 4318
-      ) {
+      // Check for direct ECONNREFUSED error (any port - collector uses dynamic ports)
+      if (error && typeof error === 'object' && error.code === 'ECONNREFUSED') {
         return true
       }
 
       // Check for AggregateError with nested connection errors
       if (error && error.errors && Array.isArray(error.errors)) {
-        return error.errors.every(
-          (e: any) =>
-            e &&
-            e.code === 'ECONNREFUSED' &&
-            (e.address === '127.0.0.1' || e.address === '::1') &&
-            e.port === 4318
-        )
+        return error.errors.every((e: any) => e && e.code === 'ECONNREFUSED')
+      }
+
+      // Check for serialized error format from Vitest
+      if (typeof error === 'string' && error.includes('ECONNREFUSED')) {
+        return true
       }
 
       return false

--- a/packages/node/test/integration/otel-collector-config.yaml
+++ b/packages/node/test/integration/otel-collector-config.yaml
@@ -42,6 +42,18 @@ exporters:
       num_consumers: 10
       queue_size: 1000
 
+  # Forward traces to Honeycomb for validation
+  otlphttp/honeycomb:
+    endpoint: https://api.honeycomb.io
+    headers:
+      x-honeycomb-team: DIqGjbhe2kukGcfUf102cT
+    timeout: 10s
+    retry_on_failure:
+      enabled: true
+      initial_interval: 1s
+      max_interval: 5s
+      max_elapsed_time: 30s
+
 extensions:
   health_check:
     endpoint: 0.0.0.0:13133
@@ -52,4 +64,7 @@ service:
     traces:
       receivers: [otlp]
       processors: [batch]
-      exporters: [debug, otlphttp/dev]
+      exporters: 
+        - debug
+        - otlphttp/dev
+        - otlphttp/honeycomb


### PR DESCRIPTION
## Summary
- Add `otlphttp/honeycomb` exporter to integration test collector config to forward traces to Honeycomb for validation
- Fix ECONNREFUSED error suppression to handle dynamic ports and serialized error formats from Vitest

## Test plan
- [x] Integration tests pass with new collector config
- [x] Traces appear in Honeycomb during test runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)