### PR TITLE
fix(test): improve ECONNREFUSED error handling for dynamic ports

### DIFF
--- a/packages/node/test/integration/effect/fiberset/context-leak.integration.test.ts
+++ b/packages/node/test/integration/effect/fiberset/context-leak.integration.test.ts
@@ -121,26 +121,19 @@ describe('FiberSet.run Context Leakage', () => {
   // Helper to suppress harmless connection errors during test cleanup
   const suppressShutdownErrors = () => {
     const isHarmlessConnectionError = (error: any): boolean => {
-      // Check for direct error properties
-      if (
-        error &&
-        typeof error === 'object' &&
-        error.code === 'ECONNREFUSED' &&
-        (error.address === '127.0.0.1' || error.address === '::1') &&
-        error.port === 4318
-      ) {
+      // Check for direct ECONNREFUSED error (any port - collector uses dynamic ports)
+      if (error && typeof error === 'object' && error.code === 'ECONNREFUSED') {
         return true
       }
 
       // Check for AggregateError with nested connection errors
       if (error && error.errors && Array.isArray(error.errors)) {
-        return error.errors.every(
-          (e: any) =>
-            e &&
-            e.code === 'ECONNREFUSED' &&
-            (e.address === '127.0.0.1' || e.address === '::1') &&
-            e.port === 4318
-        )
+        return error.errors.every((e: any) => e && e.code === 'ECONNREFUSED')
+      }
+
+      // Check for serialized error format from Vitest
+      if (typeof error === 'string' && error.includes('ECONNREFUSED')) {
+        return true
       }
 
       return false


### PR DESCRIPTION
## Summary
Simplify ECONNREFUSED error suppression in integration tests to handle:
- Dynamic collector ports (removes hardcoded port 4318 check)
- Serialized error formats from Vitest
- AggregateError with nested connection errors

## Motivation
The previous implementation checked for specific port numbers, which breaks when collectors use dynamic ports. This makes the tests more robust.

## Changes
- Remove port number checks from error suppression
- Add handling for serialized error strings from Vitest
- Simplify AggregateError handling logic

## Test plan
- [x] Integration tests pass with dynamic port assignments
- [x] Error suppression works correctly during collector shutdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)