### PR TITLE
ci: test on Node 24 (unit matrix + integration)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,12 +64,16 @@ jobs:
           fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}
 
-  # Integration tests - only on Node 20
+  # Integration tests - on the supported floor (20) and atrim's runtime (24)
   integration:
-    name: Integration Tests
+    name: Integration Tests (Node ${{ matrix.node-version }})
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: test
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [20, 24]
 
     steps:
       - name: Checkout code
@@ -80,10 +84,10 @@ jobs:
         with:
           version: ${{ env.PNPM_VERSION }}
 
-      - name: Setup Node.js 20
+      - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: ${{ matrix.node-version }}
           cache: ${{ github.actor != 'dependabot[bot]' && 'pnpm' || '' }}
 
       - name: Setup Bun

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [20, 22]
+        node-version: [20, 22, 24]
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary

Test the library against **Node 24** (the runtime `atrim`, the main downstream consumer, runs on) in CI:

1. **Unit `test` job** matrix: `[20, 22]` → `[20, 22, 24]`
2. **Integration Tests** job: was Node 20 only → now a `[20, 24]` matrix. This is the job that exercises the real SDK → exporter → collector path via testcontainers, so it's where a Node-version regression would actually surface.

## What this is *not*

- **No `engines` change.** All packages stay `"node": ">=20.0.0"`. Raising the floor would break Node 20/22 consumers and is unnecessary — the library already runs on 24 (verified locally during the 0.10.0 OTel bump: SDK init + spans on Node 24.18.0).
- **Package Validation and Release stay on Node 20** — intentionally. Packing/publishing on the supported floor guarantees the artifact is valid across the whole `>=20` range.

The Codecov upload remains gated to Node 20 (`if: matrix.node-version == 20`), so no duplicate uploads.

## Cost note

The integration job now runs twice (Docker collector per Node version), roughly ~2× wall-clock for that job. The unit `test` legs are cheap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
