### PR TITLE
ci(release): use a GitHub App token instead of a personal PAT

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,8 +21,24 @@ jobs:
       id-token: write  # Required for npm OIDC trusted publishing
 
     steps:
+      # Mint a short-lived installation token from the release GitHub App.
+      # Using an App token (instead of a personal PAT) means releases aren't
+      # tied to one person's account and don't silently break when a PAT
+      # expires. It also lets the pushed "version packages" PR trigger CI,
+      # which the default GITHUB_TOKEN cannot do.
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          # Persist the App token so the branch/PR push in the changesets
+          # step is authenticated as the App.
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -55,7 +71,7 @@ jobs:
           commit: "chore: version packages"
           title: "chore: version packages"
         env:
-          GITHUB_TOKEN: ${{ secrets.CHANGESET_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           NPM_CONFIG_PROVENANCE: true
 
       - name: Send publish notification


### PR DESCRIPTION
## Summary

Replaces the personal PAT (`secrets.CHANGESET_TOKEN`) that the Release workflow used to authenticate the changesets action with a short-lived **GitHub App installation token** minted via [`actions/create-github-app-token`](https://github.com/actions/create-github-app-token).

## Why

The 0.10.0 release failed on the first attempt with `HttpError: Bad credentials` — the `CHANGESET_TOKEN` PAT had expired. Personal PATs are the wrong tool for release automation:

- They expire on a fixed date and silently break releases (exactly what happened).
- They're tied to one person's account and inherit that person's access.
- They vanish if that person leaves the org.

A GitHub App token avoids all three: it's owned by the org, auto-expires per-run (short-lived, safer), and still lets the pushed "version packages" PR trigger downstream CI (which the default `GITHUB_TOKEN` cannot).

npm auth is unaffected — publishing still uses OIDC/provenance (`id-token: write`, `NPM_CONFIG_PROVENANCE: true`). This PR only swaps the *GitHub* token.

## ⚠️ DO NOT MERGE until the App exists and secrets are set

Merging before the two new secrets are present will break the Release workflow (the `create-github-app-token` step will fail). Steps:

### 1. Create the GitHub App (org: `atrim-ai`)
Org **Settings → Developer settings → GitHub Apps → New GitHub App**:
- **Name:** e.g. `atrim-release-bot`
- **Homepage URL:** the repo URL (any valid URL)
- **Webhook:** uncheck **Active** (not needed)
- **Repository permissions:**
  - **Contents:** Read and write  *(push branch, tags, GitHub releases)*
  - **Pull requests:** Read and write  *(open the version PR)*
  - *(everything else: No access)*
- **Where can this App be installed:** Only this account
- **Create**, then note the **App ID**.

### 2. Generate a private key
On the App's page → **Private keys → Generate a private key** → downloads a `.pem`. Keep it safe (it's shown once).

### 3. Install the App on the repo
App page → **Install App** → install on `atrim-ai`, scoped to **`atrim-ai/instrumentation`** (Only select repositories).

### 4. Add the two repo secrets
Repo **Settings → Secrets and variables → Actions → New repository secret**:
- `RELEASE_APP_ID` = the App ID (number)
- `RELEASE_APP_PRIVATE_KEY` = the full contents of the `.pem` (including the `-----BEGIN/END-----` lines)

### 5. Merge this PR
Then the next changeset-driven release runs entirely on the App token. `CHANGESET_TOKEN` can be deleted afterward.

## Verifying
After merge, the simplest check is the next release: push a changeset to `main` and confirm the Release workflow opens the version PR without a credentials error. (This PR's own CI only builds/lints — the token path only exercises on `main`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
